### PR TITLE
Add dummy thumbnails to eurostat data

### DIFF
--- a/catalogue/eurostat/__collection__.yaml
+++ b/catalogue/eurostat/__collection__.yaml
@@ -87,4 +87,4 @@ providers:
   url: https://ec.europa.eu/eurostat/web/main/home
 assets:
   thumbnail:
-    href:
+    href: https://apps.mundialis.de/thumbnails/1/thumbnail.png

--- a/catalogue/eurostat/geoprocessed-eurostat-chdd/__item__.yaml
+++ b/catalogue/eurostat/geoprocessed-eurostat-chdd/__item__.yaml
@@ -51,7 +51,7 @@ providers:
   url: https://www.mundialis.de/
 assets:
   thumbnail:
-    href: XXX
+    href: https://apps.mundialis.de/thumbnails/2/thumbnail.png
     roles:
     - thumbnail
   data:

--- a/catalogue/eurostat/geoprocessed-eurostat-mortality/__item__.yaml
+++ b/catalogue/eurostat/geoprocessed-eurostat-mortality/__item__.yaml
@@ -62,7 +62,7 @@ providers:
   url: https://www.mundialis.de/
 assets:
   thumbnail:
-    href: XXX
+    href: https://apps.mundialis.de/thumbnails/3/thumbnail.png
     roles:
     - thumbnail
   data:

--- a/catalogue/eurostat/geoprocessed-eurostat-population/__item__.yaml
+++ b/catalogue/eurostat/geoprocessed-eurostat-population/__item__.yaml
@@ -62,7 +62,7 @@ providers:
   url: https://www.mundialis.de/
 assets:
   thumbnail:
-    href: XXX
+    href: https://apps.mundialis.de/thumbnails/4/thumbnail.png
     roles:
     - thumbnail
   data:

--- a/catalogue/eurostat/geoprocessed-eurostat-sdg07/__item__.yaml
+++ b/catalogue/eurostat/geoprocessed-eurostat-sdg07/__item__.yaml
@@ -66,7 +66,7 @@ providers:
   url: https://www.mundialis.de/
 assets:
   thumbnail:
-    href: XXX
+    href: https://apps.mundialis.de/thumbnails/5/thumbnail.png
     roles:
     - thumbnail
   data:


### PR DESCRIPTION
This PR adds thumbnail URLs to the eurostat data. This way they can be easily switched without deployment until it is decided which images to use.